### PR TITLE
Add Capacitor UI for Flux with Traefik routing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,34 @@
 services:
 
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - core
+
+  capacitor:
+    image: fluxcd/flux2:v2.1.2
+    command:
+      - flux
+      - ui
+      - --address=0.0.0.0:9000
+    networks:
+      - core
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.capacitor.rule=Host(`capacitor.local`)"
+      - "traefik.http.routers.capacitor.entrypoints=web"
+      - "traefik.http.services.capacitor.loadbalancer.server.port=9000"
+
   grafana:
     image: grafana/grafana:latest
     environment:


### PR DESCRIPTION
## Summary
- Adds Traefik reverse proxy service for local routing
- Adds Capacitor UI service using the official Flux2 container
- Configures routing so Capacitor UI is accessible at capacitor.local
- Traefik dashboard available at localhost:8080 for debugging

## Test plan
- [ ] Run `docker compose up -d` to start all services
- [ ] Add `127.0.0.1 capacitor.local` to /etc/hosts
- [ ] Verify Capacitor UI is accessible at http://capacitor.local
- [ ] Verify Traefik dashboard at http://localhost:8080

🤖 Generated with [Claude Code](https://claude.ai/code)