### PR TITLE
Fix Kubernetes health probes to prevent pod restarts

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -38,13 +38,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /health
               port: metrics
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /health
               port: metrics
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Add dedicated `/health` endpoint for Kubernetes probes
- Update Helm chart to use `/health` instead of `/metrics` for readiness/liveness checks
- Fix metrics endpoint to handle empty inverter list gracefully

## Problem
The Kubernetes deployment was failing readiness and liveness checks because the `/metrics` endpoint wasn't available until the initial inverter scan completed. This caused pods to be killed and restarted before they could complete discovery.

## Solution
- Created a lightweight `/health` endpoint that returns 200 OK immediately
- Updated the Kubernetes deployment manifest to use `/health` for both probes
- Modified `/metrics` to return an empty response (with warning log) when no inverters are discovered yet

## Test plan
- [x] Tested `/health` endpoint locally - returns "OK" immediately
- [x] Tested `/metrics` endpoint with discovered inverters - returns proper metrics
- [x] Built and tested Docker image - health checks pass
- [x] Verified no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)